### PR TITLE
Remove unneeded step

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,17 @@ $ cd hello-react
 $ yarn install
 ```
 
-### Upgrade to latest react-scripts
+### Update browsers list
 
-This is needed to get Babel 7 and compile Vaadin components properly.
-
-```sh
-$ yarn upgrade react-scripts@next
-```
-
-Note: Vaadin components support modern browsers and IE11, so the `browserslist` section
-in `package.json`, which is added when upgrading, should be updated to look like this:
+Vaadin components support modern browsers and IE11, so the `browserslist` section
+in `package.json` should be updated to look like this:
 
 ```js
   "browserslist": [
     "last 2 versions",
-    "ie 11"
+    "not dead",
+    "ie 11",
+    "not op_mini all"
   ]
 ```
 


### PR DESCRIPTION
React-scripts provided by latest version of `create-react-app` is already 2.0.0+ so no need to upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-react/21)
<!-- Reviewable:end -->
